### PR TITLE
Fixes #11 Previously good 10.8.1 Template failing on deployment

### DIFF
--- a/Releases/10.8.1/Templates/basedeployment-multi-tier.json
+++ b/Releases/10.8.1/Templates/basedeployment-multi-tier.json
@@ -2112,7 +2112,7 @@
           "resources": [
             {
               "type": "Microsoft.Network/applicationGateways",
-              "apiVersion": "2019-04-01",
+              "apiVersion": "2021-02-01",
               "name": "[parameters('appGatewayName')]",
               "location": "[parameters('location')]",
               "tags": APPGATEWAYTAGS,

--- a/Releases/10.8.1/Templates/basedeployment-single-tier.json
+++ b/Releases/10.8.1/Templates/basedeployment-single-tier.json
@@ -1409,7 +1409,7 @@
           "resources": [
             {
               "type": "Microsoft.Network/applicationGateways",
-              "apiVersion": "2019-04-01",
+              "apiVersion": "2021-02-01",
               "name": "[parameters('appGatewayName')]",
               "location": "[parameters('location')]",
               "tags": APPGATEWAYTAGS,

--- a/Releases/10.8.1/Templates/gisserver-multi-tier.json
+++ b/Releases/10.8.1/Templates/gisserver-multi-tier.json
@@ -1582,7 +1582,7 @@
           "resources": [
             {
               "type": "Microsoft.Network/applicationGateways",
-              "apiVersion": "2019-04-01",
+              "apiVersion": "2021-02-01",
               "name": "[parameters('appGatewayName')]",
               "location": "[parameters('location')]",
               "tags": APPGATEWAYTAGS,

--- a/Releases/10.8.1/Templates/gisserver-single-tier.json
+++ b/Releases/10.8.1/Templates/gisserver-single-tier.json
@@ -1367,7 +1367,7 @@
           "resources": [
             {
               "type": "Microsoft.Network/applicationGateways",
-              "apiVersion": "2019-04-01",
+              "apiVersion": "2021-02-01",
               "name": "[parameters('appGatewayName')]",
               "location": "[parameters('location')]",
               "tags": APPGATEWAYTAGS,


### PR DESCRIPTION
Updated the ApplicationGateway API version to the same version that is used in the 10.9.1 templates. The later versions of the API use the "Priority" property that is causing the error in #11  